### PR TITLE
Duration Fields from Integers to Longs

### DIFF
--- a/src/main/java/org/greenbuttonalliance/gbaresourceserver/usage/dto/DateTimeInterval.java
+++ b/src/main/java/org/greenbuttonalliance/gbaresourceserver/usage/dto/DateTimeInterval.java
@@ -29,6 +29,6 @@ import java.io.Serializable;
 @Setter
 @Accessors(chain = true)
 public class DateTimeInterval implements Serializable {
-	private Integer duration; // in epoch-seconds
+	private Long duration; // in epoch-seconds
 	private Long start; // in seconds
 }

--- a/src/main/java/org/greenbuttonalliance/gbaresourceserver/usage/model/IntervalBlock.java
+++ b/src/main/java/org/greenbuttonalliance/gbaresourceserver/usage/model/IntervalBlock.java
@@ -43,7 +43,7 @@ public class IntervalBlock extends IdentifiedObject {
 	private Long start; // in epoch-seconds
 
 	@Column
-	private Integer duration; // in seconds
+	private Long duration; // in seconds
 
 	@OneToMany(mappedBy = "block", cascade = CascadeType.ALL)
 	private Set<IntervalReading> intervalReadings = new HashSet<>();

--- a/src/main/java/org/greenbuttonalliance/gbaresourceserver/usage/model/IntervalReading.java
+++ b/src/main/java/org/greenbuttonalliance/gbaresourceserver/usage/model/IntervalReading.java
@@ -54,7 +54,7 @@ public class IntervalReading {
 	private Long start; // in epoch-seconds
 
 	@Column
-	private Integer duration; // in seconds
+	private Long duration; // in seconds
 
 	@Column
 	private Long value; // in units specified by associated ReadingType

--- a/src/main/resources/db/migration/V0.1.5__duration_integer_to_bigint.sql
+++ b/src/main/resources/db/migration/V0.1.5__duration_integer_to_bigint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE usage.interval_block ALTER COLUMN duration TYPE BIGINT;
+ALTER TABLE usage.interval_reading ALTER COLUMN duration TYPE BIGINT;

--- a/src/test/java/org/greenbuttonalliance/gbaresourceserver/usage/repository/IntervalBlockRepositoryTest.java
+++ b/src/test/java/org/greenbuttonalliance/gbaresourceserver/usage/repository/IntervalBlockRepositoryTest.java
@@ -131,12 +131,12 @@ public class IntervalBlockRepositoryTest {
 				.upLinkRel("up")
 				.updated(LocalDateTime.parse("2012-03-02 05:00:00", SQL_FORMATTER))
 				.start(1330578000L)
-				.duration(1800)
+				.duration(1800L)
 				.intervalReadings(Stream.of(
 					new IntervalReading()
 						.setCost(974L)
 						.setStart(1330578000L)
-						.setDuration(900)
+						.setDuration(900L)
 						.setValue(285L)
 						.setReadingQualities(
 							Stream.of(new ReadingQuality().setQuality(QualityOfReading.VALID),
@@ -146,7 +146,7 @@ public class IntervalBlockRepositoryTest {
 					new IntervalReading()
 						.setCost(965L)
 						.setStart(1330578900L)
-						.setDuration(900)
+						.setDuration(900L)
 						.setValue(383L)
 						.setReadingQualities(
 							Stream.of(new ReadingQuality().setQuality(QualityOfReading.OTHER),
@@ -162,12 +162,12 @@ public class IntervalBlockRepositoryTest {
 				.upLinkRel("up")
 				.updated(LocalDateTime.parse("2012-03-03 05:00:00", SQL_FORMATTER))
 				.start(1330578800L)
-				.duration(900)
+				.duration(900L)
 				.intervalReadings(Stream.of(
 					new IntervalReading()
 						.setCost(922L)
 						.setStart(1330578800L)
-						.setDuration(900)
+						.setDuration(900L)
 						.setValue(350L)
 						.setReadingQualities(
 							Stream.of(new ReadingQuality().setQuality(QualityOfReading.VALID))
@@ -182,7 +182,7 @@ public class IntervalBlockRepositoryTest {
 				.upLinkRel("up")
 				.updated(LocalDateTime.parse("2012-03-04 05:00:00", SQL_FORMATTER))
 				.start(1330987644L)
-				.duration(900)
+				.duration(900L)
 				.intervalReadings(Collections.emptySet())
 				.build()
 		);


### PR DESCRIPTION
The `duration` fields for `IntervalBlock` and `IntervalReading` are currently `Integer`s, but they should be `Long`s to match the NAESB standard. The associated database and DTO fields, and test data have been updated as well.